### PR TITLE
remove name restriction test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@laylo.com/partner",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "author": "Laylo",
   "description": "The official Laylo partner Node.js SDK",
   "main": "./dist/index.js",

--- a/src/conversions/track/tests/hasTrackError.test.ts
+++ b/src/conversions/track/tests/hasTrackError.test.ts
@@ -59,23 +59,6 @@ describe("hasTrackError", () => {
     );
   });
 
-  it("should return an error message if name is invalid", () => {
-    const name = "KNICKS@LAKERS";
-
-    const result = hasTrackError({
-      configuration,
-      action,
-      name,
-      user,
-      metadata,
-      customerApiKey,
-    });
-
-    expect(result).toBe(
-      "The event name can only contain letters, numbers, underscores, hyphens, forward slashes, and spaces."
-    );
-  });
-
   it("should return an error message if customerApiKey is invalid", () => {
     const customerApiKey = "";
 


### PR DESCRIPTION
Remove the name restriction test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the version of the `@laylo.com/partner` package to 0.0.8, indicating minor improvements and ongoing development.
  
- **Bug Fixes**
	- Removed a test case for invalid event names in the `hasTrackError` function, which may streamline testing but could impact error handling robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->