### PR TITLE
add integratorId, productId, and custom source

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@laylo.com/partner",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "author": "Laylo",
   "description": "The official Laylo partner Node.js SDK",
   "main": "./dist/index.js",

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -8,5 +8,6 @@ export const config = (config: Configuration) => {
     id: config.id,
     accessKey: config.accessKey,
     secretKey: config.secretKey,
+    companyName: config.companyName,
   };
 };

--- a/src/config/tests/config.test.ts
+++ b/src/config/tests/config.test.ts
@@ -1,11 +1,13 @@
+import { Configuration } from "config/types";
 import { config, configuration } from "../config";
 
 describe("config", () => {
   it("should set configuration", () => {
-    const configData = {
+    const configData: Configuration = {
       id: "LAYLO_ACCOUNT_ID",
       accessKey: "LAYLO_ACCESS_KEY",
       secretKey: "LAYLO_SECRET_KEY",
+      companyName: "COMPANY_NAME",
     };
     config(configData);
     expect(configuration).toEqual(configData);

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -5,4 +5,6 @@ export type Configuration = {
   accessKey: string;
   /** This can be retrieved when creating a Laylo API Key */
   secretKey: string;
+  /** The name of your company. Used as the 'source' string for conversion events. */
+  companyName: string;
 };

--- a/src/conversions/track/tests/hasTrackError.test.ts
+++ b/src/conversions/track/tests/hasTrackError.test.ts
@@ -1,14 +1,16 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { Configuration } from "config";
 import { hasTrackError } from "../hasTrackError";
 
 describe("hasTrackError", () => {
   // ignore the console.error messages
   jest.spyOn(console, "error").mockImplementation();
 
-  const configuration = {
+  const configuration: Configuration = {
     id: "AN_ID",
     accessKey: "AN_ACCESS_KEY",
     secretKey: "A_SECRET_KEY",
+    companyName: "A_COMPANY_NAME",
   };
   const action = "PURCHASE";
   const name = "MSG Square - 05/21/22";
@@ -22,10 +24,11 @@ describe("hasTrackError", () => {
   const customerApiKey = "A_CUSTOMER_API_KEY";
 
   it("should return an error message if configuration is invalid", () => {
-    const configuration = {
+    const configuration: Configuration = {
       id: "",
       accessKey: "",
       secretKey: "",
+      companyName: "A_COMPANY_NAME",
     };
 
     const result = hasTrackError({

--- a/src/conversions/track/tests/track.test.ts
+++ b/src/conversions/track/tests/track.test.ts
@@ -22,6 +22,7 @@ describe("track", () => {
       id: "AN_ID",
       accessKey: "AN_ACCESS_KEY",
       secretKey: "A_SECRET_KEY",
+      companyName: "A_COMPANY_NAME",
     });
     const action = "PURCHASE";
     const name = "MSG Square - 05/21/22";
@@ -40,6 +41,7 @@ describe("track", () => {
       user,
       metadata,
       customerApiKey,
+      layloProductId: "FOO",
     });
 
     expect(result).toMatchObject({
@@ -47,9 +49,11 @@ describe("track", () => {
       payload: {
         action: "PURCHASE",
         customerApiKey: "A_CU****_KEY",
+        source: "A_COMPANY_NAME",
         metadata: {
           title: "EVENT_ID",
           value: 100,
+          productId: "FOO",
         },
         name: "MSG Square - 05/21/22",
         user: {
@@ -71,6 +75,7 @@ describe("track", () => {
       id: "",
       accessKey: "",
       secretKey: "",
+      companyName: "",
     });
     const action = "PURCHASE";
     const name = "MSG Square - 05/21/22";

--- a/src/conversions/track/track.ts
+++ b/src/conversions/track/track.ts
@@ -11,6 +11,7 @@ export const track = async ({
   metadata,
   user,
   customerApiKey,
+  layloProductId,
 }: {
   /** Categorize the action taken by the user. It can be one of the following: 'PURCHASE', 'CHECK_IN', 'ADD_TO_CART' */
   action: LayloAction;
@@ -22,6 +23,8 @@ export const track = async ({
   user: User;
   /** This is your customer's Laylo API key that they create at https://laylo.com/settings?tab=Integrations. It should be securely stored in your backend and never exposed on the frontend. */
   customerApiKey: string;
+  /** The Laylo product id that the event is associated with. */
+  layloProductId?: string;
 }): Promise<TrackResponse> => {
   const trackError = hasTrackError({
     configuration,
@@ -42,6 +45,7 @@ export const track = async ({
     metadata,
     user,
     customerApiKey,
+    layloProductId,
   });
 };
 
@@ -51,12 +55,14 @@ const sendEventToApi = async ({
   metadata,
   user,
   customerApiKey,
+  layloProductId,
 }: {
   action: LayloAction;
   name: string;
   metadata: Metadata;
   user: User;
   customerApiKey: string;
+  layloProductId?: string;
 }): Promise<TrackResponse> => {
   if (
     !configuration.accessKey ||
@@ -114,10 +120,14 @@ const sendEventToApi = async ({
           apiKey: customerApiKey,
           action,
           name,
-          source: configuration.id,
+          source: configuration.companyName,
           timestamp,
-          metadata,
+          metadata: {
+            ...metadata,
+            productId: layloProductId,
+          },
           user,
+          integratorId: configuration.id,
         },
       },
       PartitionKey: configuration.id,
@@ -138,8 +148,12 @@ const sendEventToApi = async ({
         )}****${customerApiKey.slice(-4)}`,
         action,
         name,
+        source: configuration.companyName,
         timestamp,
-        metadata,
+        metadata: {
+          ...metadata,
+          productId: layloProductId,
+        },
         user,
       },
     };

--- a/src/conversions/types.ts
+++ b/src/conversions/types.ts
@@ -1,6 +1,8 @@
 export type LayloAction = "PURCHASE" | "CHECK_IN" | "ADD_TO_CART";
 
 export type Metadata = {
+  /** The Laylo product id that the event is associated with. */
+  productId?: string;
   /** The currency code (ISO 4217) if the conversion is a transaction with a price. Ex: USD, EUR, GBP, etc. */
   currency?: string;
   /** The total price of the transaction. It must be a decimal number with no more than two decimal places (ex: 12.02, 5.00)  */
@@ -31,6 +33,7 @@ export type TrackResponse =
         customerApiKey: string;
         action: LayloAction;
         name: string;
+        source: string;
         timestamp: string;
         metadata: Metadata;
         user: User;


### PR DESCRIPTION
- Allow for a custom source name for conversion events
- Always send the integrator ID with track calls
- Optionally send a laylo product ID with track calls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new property, `companyName`, to enhance configuration options.
	- Added optional `layloProductId` parameter to tracking functions for improved event association.
	- Enhanced event tracking with new `productId` and `source` fields in metadata.

- **Bug Fixes**
	- Improved type safety in configuration and tracking test cases.

- **Documentation**
	- Updated function signatures and configuration types to reflect new properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->