### PR TITLE
add sms and email marketing consent properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 .env
+.npmrc
 /dist
 
 # dependencies

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@laylo:token=fd5be3e277f24609ba71b741f04f6183

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@laylo:token=fd5be3e277f24609ba71b741f04f6183

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@laylo.com/partner",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "author": "Laylo",
   "description": "The official Laylo partner Node.js SDK",
   "main": "./dist/index.js",

--- a/src/conversions/track/tests/hasTrackError.test.ts
+++ b/src/conversions/track/tests/hasTrackError.test.ts
@@ -18,7 +18,7 @@ describe("hasTrackError", () => {
     id: "123",
     email: "foo@foo.com",
     phone: "+1111111111",
-    marketingConsent: true,
+    smsMarketingConsent: true,
   };
   const metadata = { title: "EVENT_ID", value: 100 };
   const customerApiKey = "A_CUSTOMER_API_KEY";
@@ -84,7 +84,7 @@ describe("hasTrackError", () => {
       id: "123",
       email: "",
       phone: "",
-      marketingConsent: true,
+      smsMarketingConsent: true,
     };
 
     const result = hasTrackError({

--- a/src/conversions/track/tests/track.test.ts
+++ b/src/conversions/track/tests/track.test.ts
@@ -30,7 +30,7 @@ describe("track", () => {
       id: "123",
       email: "foo@foo.com",
       phone: "+1111111111",
-      marketingConsent: true,
+      smsMarketingConsent: true,
     };
     const metadata = { title: "EVENT_ID", value: 100 };
     const customerApiKey = "A_CUSTOMER_API_KEY";
@@ -59,7 +59,7 @@ describe("track", () => {
         user: {
           email: "foo@foo.com",
           id: "123",
-          marketingConsent: true,
+          smsMarketingConsent: true,
           phone: "+1111111111",
         },
       },
@@ -83,7 +83,7 @@ describe("track", () => {
       id: "123",
       email: "foo@foo.com",
       phone: "+1111111111",
-      marketingConsent: true,
+      smsMarketingConsent: true,
     };
     const metadata = { title: "EVENT_ID", value: 100 };
     const customerApiKey = "A_CUSTOMER_API_KEY";

--- a/src/conversions/types.ts
+++ b/src/conversions/types.ts
@@ -16,7 +16,13 @@ export type User = {
   email?: string;
   /** Include the user's phone number or email. Must be a valid phone number with a country code. `+13101234567`. We recommend validating phone numbers using the library `libphonenumber-js` before sending them. */
   phone?: string;
-  /** If this is true then the user will be subscribed to your customer when they send Laylo emails and texts. If you pass a phone number then the user will be sent a confirmation text. Ensure that you have provided the user with the proper terms, conditions, and policies. */
+  /** If this is true then the user will be subscribed to your customer when they send Laylo texts. If you pass a phone number then the user will be sent a confirmation text. Ensure that you have provided the user with the proper terms, conditions, and policies. */
+  smsMarketingConsent?: boolean;
+  /** If this is true then the user will be subscribed to your customer when they send Laylo emails. Ensure that you have provided the user with the proper terms, conditions, and policies. */
+  emailMarketingConsent?: boolean;
+  /**
+   * @deprecated Use `smsMarketingConsent` or `emailMarketingConsent` instead.
+   **/
   marketingConsent?: boolean;
   /** Add additional metadata about the user that you want to see on the event. */
   [key: string]: string | boolean | number | undefined;

--- a/src/conversions/types.ts
+++ b/src/conversions/types.ts
@@ -16,7 +16,7 @@ export type User = {
   email?: string;
   /** Include the user's phone number or email. Must be a valid phone number with a country code. `+13101234567`. We recommend validating phone numbers using the library `libphonenumber-js` before sending them. */
   phone?: string;
-  /** If this is true then the user will be subscribed to your customer when they send Laylo texts. If you pass a phone number then the user will be sent a confirmation text. Ensure that you have provided the user with the proper terms, conditions, and policies. */
+  /** If this is true then the user will be subscribed to your customer when they send Laylo texts. If you pass a phone number then the user will be sent a confirmation text. Phone must be in E.164 format (e.g., '+13101234567'). Pro tip: Use libphonenumber-js for validation before sending. Ensure that you have provided the user with the proper terms, conditions, and policies. */
   smsMarketingConsent?: boolean;
   /** If this is true then the user will be subscribed to your customer when they send Laylo emails. Ensure that you have provided the user with the proper terms, conditions, and policies. */
   emailMarketingConsent?: boolean;

--- a/src/testServer/index.ts
+++ b/src/testServer/index.ts
@@ -23,7 +23,7 @@ const server = http.createServer(async (req, res) => {
         name: "TOUR",
         action: "PURCHASE",
         metadata: { title: "EVENT_ID", value: 100 },
-        user: { phone: "+1111111111", marketingConsent: true },
+        user: { phone: "+1111111111", smsMarketingConsent: true },
       });
 
       console.log(value);


### PR DESCRIPTION
- Deprecate `marketingConsent` properties
- Add `smsMarketingConsent` and `emailMarketingConsent` properties to allow for flexibility on contact methods

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new properties for explicit consent tracking: `smsMarketingConsent` and `emailMarketingConsent` for users.
	- Updated user consent handling in tracking requests.

- **Bug Fixes**
	- Corrected user object structure in tests and tracking requests to reflect the new naming convention for SMS marketing consent.

- **Chores**
	- Updated version number in `package.json` from `0.0.9` to `0.0.10`.
	- Added `.npmrc` and `https_cert` to the ignored files list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->