### PR TITLE
Add default export so `import laylo from "@laylo.com/partner"` works

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@laylo.com/partner",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@laylo.com/partner",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@laylo.com/partner",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "author": "Laylo",
   "description": "The official Laylo partner Node.js SDK",
   "main": "./dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,3 +11,5 @@ export const laylo = {
   conversions,
   users,
 };
+
+export default laylo;


### PR DESCRIPTION
The README documents a default import (`import laylo from "@laylo.com/partner"`) but the package only exposed named exports, so the documented usage resolved to undefined for TypeScript/ESM consumers. Add `export default laylo` so the default-import examples work, alongside the existing named exports and CJS `require`. Bump to v0.0.17 for publish.